### PR TITLE
AL - Remove tests for Students menu

### DIFF
--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -212,55 +212,6 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-ucsbdates-create/)).toBeInTheDocument() );
 
     });
-
-    test("renders the Students menu correctly for a user", async () => {
-
-        const currentUser = currentUserFixtures.userOnly;
-        const systemInfo = systemInfoFixtures.showingBoth;
-
-        const doLogin = jest.fn();
-
-        const {getByTestId  } = render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
-        const dropdown = getByTestId("appnavbar-students-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-        await waitFor( () => expect(getByTestId("appnavbar-students-list")).toBeInTheDocument() );
-
-    });
-
-    test("renders the Students menu correctly for an admin", async () => {
-
-        const currentUser = currentUserFixtures.adminUser;
-        const systemInfo = systemInfoFixtures.showingBoth;
-
-        const doLogin = jest.fn();
-
-        const {getByTestId  } = render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
-        const dropdown = getByTestId("appnavbar-students-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-        await waitFor( () => expect(getByTestId(/appnavbar-students-create/)).toBeInTheDocument() );
-
-    });
-
 });
 
 


### PR DESCRIPTION
# Overview

This PR removes the tests associated with the Students navbar code that was deleted in 52ba27a. This was causing the Jest test run to fail, and therefore not allow Stryker or Codecov to work properly for the frontend.

After this change is merged, we'll need to ask the students to pull in the new changes if they want their GitHub Actions runs to pass.