### PR TITLE
AL - Fix navbar links and responsive layout

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -7,8 +7,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
   return (
     <>
       {
-        (currentUrl.startsWith("http://localhost:3000") ||
-          currentUrl.startsWith("http://127.0.0.1:3000")) && (
+        (currentUrl.startsWith("http://localhost:3000") || currentUrl.startsWith("http://127.0.0.1:3000")) && (
           <AppNavbarLocalhost url={currentUrl} />
         )
       }
@@ -20,57 +19,49 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
 
           <Navbar.Toggle />
 
-          <Nav className="me-auto">
-            {
-              systemInfo?.springH2ConsoleEnabled && (
-                <>
-                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
-                </>
-              )
-            }
-            {
-              systemInfo?.showSwaggerUILink && (
-                <>
-                  <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
-                </>
-              )
-            }
-          </Nav>
-
           <>
-            {/* be sure that each NavDropdown has a unique id and data-testid  */}
+            {/* be sure that each NavDropdown has a unique id and data-testid */}
           </>
 
-          <Navbar.Collapse className="justify-content-between">
-            <Nav className="mr-auto">
+          <Navbar.Collapse>
+            {/* This `nav` component contains all navigation items that show up on the left side */}
+            <Nav className="me-auto">
+              {
+                systemInfo?.springH2ConsoleEnabled && (
+                  <>
+                    <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                  </>
+                )
+              }
+              {
+                systemInfo?.showSwaggerUILink && (
+                  <>
+                    <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
+                  </>
+                )
+              }
               {
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
-                    <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/admin/users">Users</NavDropdown.Item>
                   </NavDropdown>
                 )
               }
-            </Nav>
-
-            <Nav className="mr-auto">
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Todos" id="appnavbar-todos-dropdown" data-testid="appnavbar-todos-dropdown" >
-                    <NavDropdown.Item href="/todos/list">List Todos</NavDropdown.Item>
-                    <NavDropdown.Item href="/todos/create">Create Todo</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/todos/list">List Todos</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/todos/create">Create Todo</NavDropdown.Item>
                   </NavDropdown>
                 )
               }
-            </Nav>
-
-            <Nav className="mr-auto">
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="UCSBDates" id="appnavbar-ucsbdates-dropdown" data-testid="appnavbar-ucsbdates-dropdown" >
-                    <NavDropdown.Item href="/ucsbdates/list" data-testid="appnavbar-ucsbdates-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/ucsbdates/list" data-testid="appnavbar-ucsbdates-list">List</NavDropdown.Item>
                     {
                       hasRole(currentUser, "ROLE_ADMIN") && (
-                        <NavDropdown.Item href="/ucsbdates/create" data-testid="appnavbar-ucsbdates-create">Create</NavDropdown.Item>
+                        <NavDropdown.Item as={Link} to="/ucsbdates/create" data-testid="appnavbar-ucsbdates-create">Create</NavDropdown.Item>
                       )
                     }
                   </NavDropdown>
@@ -79,6 +70,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
             </Nav>
 
             <Nav className="ml-auto">
+              {/* This `nav` component contains all navigation items that show up on the right side */}
               {
                 currentUser && currentUser.loggedIn ? (
                   <>

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -212,55 +212,6 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-ucsbdates-create/)).toBeInTheDocument() );
 
     });
-
-    test("renders the Students menu correctly for a user", async () => {
-
-        const currentUser = currentUserFixtures.userOnly;
-        const systemInfo = systemInfoFixtures.showingBoth;
-
-        const doLogin = jest.fn();
-
-        const {getByTestId  } = render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
-        const dropdown = getByTestId("appnavbar-students-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-        await waitFor( () => expect(getByTestId("appnavbar-students-list")).toBeInTheDocument() );
-
-    });
-
-    test("renders the Students menu correctly for an admin", async () => {
-
-        const currentUser = currentUserFixtures.adminUser;
-        const systemInfo = systemInfoFixtures.showingBoth;
-
-        const doLogin = jest.fn();
-
-        const {getByTestId  } = render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
-        const dropdown = getByTestId("appnavbar-students-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-        await waitFor( () => expect(getByTestId(/appnavbar-students-create/)).toBeInTheDocument() );
-
-    });
-
 });
 
 


### PR DESCRIPTION
# Overview

This PR makes the following fixes to the navbar such that it is properly using Bootstrap:

* Elements on the left side on the navbar all share one `Nav` object
* H2Console and Swagger UI links were moved into the left side `Nav` object
* `justify-content-between` class was removed
* Links now use the React Router Link component instead of `href` - this prevents page refreshes

Note that this change also includes the changes from #1 so the frontend tests will pass. Please merge that PR first.

# Link to Storybook

Storybook isn't set up in this repo so you'll have to build locally

# Details

Old navbar on wide (Desktop) viewports

![image](https://user-images.githubusercontent.com/34492835/163361746-f4c948b5-d82b-415b-9d4c-7c0a609103ca.png)

Old navbar on skinny (Mobile) viewports

![image](https://user-images.githubusercontent.com/34492835/163361648-3ae8aa96-c20c-432b-9ff1-6e823d4b3ea6.png)

New navbar on wide (Desktop) viewports

![image](https://user-images.githubusercontent.com/34492835/163361231-35379b1b-1626-44ae-b499-15ec5bd9f5ca.png)

New navbar on skinny (Mobile) viewports

![image](https://user-images.githubusercontent.com/34492835/163361447-d649b5d5-9fc4-4b6e-8302-a7ac45b3da1b.png)
